### PR TITLE
mpl for FPP histograms

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ extensions = [
 templates_path = ['_templates']
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
-autodoc_mock_imports = ['IPython', 'pandas', 'numpy']
+autodoc_mock_imports = ['IPython', 'pandas', 'numpy', 'matplotlib']
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pandas
 numpy
 scipy
 IPython
+matplotlib

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
         'Documentation': 'https://statwrap.readthedocs.io/'
     },
     author='Alexander Clark',
-    install_requires=['pandas','numpy','scipy', 'IPython'],
+    install_requires=['pandas','numpy','scipy', 'IPython', 'matplotlib'],
     author_email='',  # consider adding your email
     packages=setuptools.find_packages(),
     zip_safe=False,

--- a/statwrap/fpp.py
+++ b/statwrap/fpp.py
@@ -3,6 +3,7 @@ Stats functions adapted to the conventions of Freedman, Pisani, and Purves 2007.
 '''
 import numpy as np
 import pandas as pd
+import matplotlib.pyplot as plt
 from IPython.core.magic import register_line_magic
 from statwrap.utils import modify_std, args_to_array
 
@@ -15,7 +16,7 @@ def average(*args):
     args : array_like or numeric scalars
         Input data. This can be a single array-like object or individual numbers.
         Both average([1,2]) and average(1,2) are valid.
-    
+
     Returns:
     --------
     float
@@ -39,7 +40,7 @@ def rms_size(*args):
     args : array_like or numeric scalars
         Input data. This can be a single array-like object or individual numbers.
         Both rms_size([1,2]) and rms_size(1,2) are valid.
-    
+
     Returns:
     --------
     float
@@ -104,7 +105,7 @@ def var(*args):
 
     >>> var(-1, 0, 1)
     0.6666666666666666
-    
+
     """
     a = args_to_array(args)
     return np.var(a, ddof=0)
@@ -128,10 +129,10 @@ def sd_plus(*args):
     --------
     >>> sd_plus([-1, 0, 1])
     1.0
-    
+
     >>> sd_plus(-1, 0, 1)
     1.0
-    
+
     """
     a = args_to_array(args)
     return np.std(a, ddof=1)
@@ -164,15 +165,84 @@ def var_plus(*args):
     return np.var(a, ddof=1)
 
 def change_std_behavior(pd_obj):
-	original = getattr(pd_obj, 'std')
-	pop_std, sample_std = modify_std(original)
-	setattr(pd_obj, 'std', pop_std)
-	setattr(pd_obj, 'sd', pop_std)
-	setattr(pd_obj, 'sd_plus', sample_std)
+    original = getattr(pd_obj, 'std')
+    pop_std, sample_std = modify_std(original)
+    setattr(pd_obj, 'std', pop_std)
+    setattr(pd_obj, 'sd', pop_std)
+    setattr(pd_obj, 'sd_plus', sample_std)
 
 def apply_pd_changes():
-	change_std_behavior(pd.DataFrame)
-	change_std_behavior(pd.Series)
+    change_std_behavior(pd.DataFrame)
+    change_std_behavior(pd.Series)
+
+def histogram(x, bins=None, density=False, xlim=None, ylim=None, ax=None, show=True, save_as=None, **kwargs):
+    '''
+    Creates a histogram using matplotlib.
+
+    Parameters:
+    ----------
+    x : array-like or sequence or array-likes
+        Input data to be plotted as a histogram.
+
+    bins : int or sequence, optional
+        The number of bins or the bin edges if a sequence is provided. If not provided, defaults are used.
+
+    density : bool, default False
+        If True, normalizes the histogram so that the total area is equal to 1.
+
+    xlim : tuple, optional
+        The x-axis limits as (min, max). If not provided, defaults are used.
+
+    ylim : tuple, optional
+        The y-axis limits as (min, max). If not provided, defaults are used.
+
+    ax : matplotlib axes object, optional
+        An existing axes to draw the histogram on. If None, a new figure and axes are created.
+
+    show : bool, default True
+        If True, displays the plot. Otherwise, it returns the figure and axis.
+
+    save_as : str, optional
+        If a string is provided, the figure is saved with the given filename.
+        This must include an extension like '.png' or '.pdf'.
+
+    kwargs : dict
+        Additional keyword arguments to pass to `ax.hist`.
+
+    Returns:
+    -------
+    fig, ax : tuple
+        A tuple containing the figure and axis objects. Only returned if `show` is False.
+
+    Examples
+    --------
+    >>> histogram([1,2,3,3,3], save_as = 'example.png')
+    (histogram will appear in notebook output)
+    '''
+    if ax is None:
+        fig, ax = plt.figure(), plt.axes()
+
+    # Documented parameters
+    kwargs['bins'] = bins
+    kwargs['density'] = density
+
+    # I like black edges
+    if ('edgecolor' not in kwargs) and ('ec' not in kwargs):
+            kwargs['ec'] = 'black'
+
+    ax.hist(x, **kwargs)
+
+    if xlim is not None:
+        ax.set_xlim(xlim)
+    if ylim is not None:
+        ax.set_ylim(ylim)
+
+    if save_as is not None:
+        plt.savefig(save_as)
+    if show:
+        plt.show()
+    else:
+        return fig, ax
 
 def fpp_setup():
-	apply_pd_changes()
+    apply_pd_changes()

--- a/tests/test_fpp.py
+++ b/tests/test_fpp.py
@@ -1,5 +1,6 @@
 import unittest
 import pandas as pd
+import matplotlib.pyplot as plt
 from statwrap.fpp import apply_pd_changes, sd
 
 class TestStd(unittest.TestCase):


### PR DESCRIPTION
Add matplotlib wrapper for ax.hist()

This simplifies ax.hist() by using the full name histogram and moving options like saving and xlim, ylim inside the function. 