### PR TITLE
Linest improvements

### DIFF
--- a/statwrap/sheets.py
+++ b/statwrap/sheets.py
@@ -5,8 +5,15 @@ import numpy as np
 import pandas as pd
 import scipy.stats as stats
 import statsmodels.api as sm
+import warnings
 from IPython.core.magic import register_line_magic
-from statwrap.utils import modify_std, args_to_array, hyperlink, Hyperplane, RegressionLine
+from statwrap.utils import (
+    modify_std, 
+    args_to_array, 
+    hyperlink, 
+    Hyperplane, 
+    RegressionLine, 
+)
 
 @hyperlink
 def linest(y, x, verbose = False):
@@ -305,4 +312,5 @@ def apply_pd_changes():
     change_std_behavior(pd.Series)
 
 def sheets_setup():
+    warnings.filterwarnings("ignore", message="omni_normtest is not valid with less than 8 observations")
     apply_pd_changes()

--- a/statwrap/utils.py
+++ b/statwrap/utils.py
@@ -238,8 +238,8 @@ class Hyperplane:
         terms = [f'{round(self.coefficients[0],3):g}']
         for i, coef in enumerate(self.coefficients[1:], 1):
             coef = round(coef, 3)
-            terms.append(f'{coef:g} x_{i}')
-        return r'$\hat{y} = ' + ' + '.join(terms) + "$"
+            terms.append(f'{coef:+g} x_{i}')
+        return r'$\hat{y} = ' + ' '.join(terms) + "$"
 
     def predict(self, data, add_constant = True, dataframe = True):
 


### PR DESCRIPTION
Change utils.Hyperplane _repr_latex_ method to avoid inelegant "+ -2x" stuff when printing the equation. 

Also update %use_sheets to suppress some warnings on statsmodels OLS().fit(). 