### PR TITLE
statwrap.fpp.scatter_plot update– inbuilt regline equation

### DIFF
--- a/statwrap/fpp.py
+++ b/statwrap/fpp.py
@@ -54,7 +54,7 @@ def box_model(*args, with_replacement = True, draws = 1, random_seed = None):
 
 def scatter_plot(x, y, xlim=None, ylim=None,
               ax=None, show=True, save_as=None, xlabel=None,
-              ylabel=None, title=None, regression_line=False, regression_equation=False **kwargs):
+              ylabel=None, title=None, regression_line=False, regression_equation=False, **kwargs):
     """
     Create a scatter plot of `x` versus `y`, with specified axis labels, limits, title, and other properties.
     Optionally, a regression line can be added to the plot.

--- a/statwrap/fpp.py
+++ b/statwrap/fpp.py
@@ -133,7 +133,7 @@ def scatter_plot(x, y, xlim=None, ylim=None,
     if ylabel is not None:
         ax.set_ylabel(ylabel)
     if title is not None:
-        pad=12 if regression_equation else None
+	pad=12 if regression_equation else None
 	ax.set_title(title, pad=pad)
 
     if save_as is not None:

--- a/statwrap/fpp.py
+++ b/statwrap/fpp.py
@@ -119,7 +119,7 @@ def scatter_plot(x, y, xlim=None, ylim=None,
 
     if regression_equation: 
         equation_text = f'y = {m:.2f}x + {b:.2f}'  # Add regression line equation to plot
-        ax.text(0.5 , 1, equation_text, transform=ax.transAxes, fontsize=10,
+        ax.text(0.5, 1, equation_text, transform=ax.transAxes, fontsize=10,
                 verticalalignment='bottom', horizontalalignment='center', alpha=0.5)
 
     if xlim is not None:
@@ -131,7 +131,7 @@ def scatter_plot(x, y, xlim=None, ylim=None,
     if ylabel is not None:
         ax.set_ylabel(ylabel)
     if title is not None:
-        ax.set_title(title)
+        ax.set_title(title, pad=12)
 
     if save_as is not None:
         plt.savefig(save_as)

--- a/statwrap/fpp.py
+++ b/statwrap/fpp.py
@@ -133,8 +133,8 @@ def scatter_plot(x, y, xlim=None, ylim=None,
     if ylabel is not None:
         ax.set_ylabel(ylabel)
     if title is not None:
-	pad=12 if regression_equation else None
-	ax.set_title(title, pad=pad)
+        pad=12 if regression_equation else None
+        ax.set_title(title, pad=pad)
 
     if save_as is not None:
         plt.savefig(save_as)

--- a/statwrap/fpp.py
+++ b/statwrap/fpp.py
@@ -112,8 +112,9 @@ def scatter_plot(x, y, xlim=None, ylim=None,
     y = np.squeeze(np.array(y))
     ax.scatter(x, y, **kwargs)
 
-    if regression_line:
-        m, b = np.polyfit(x, y, 1)  # Calculating the slope (m) and intercept (b) of the regression line
+    m, b = np.polyfit(x, y, 1)  # Calculating the slope (m) and intercept (b) of the regression line
+    
+    if regression_line:    
         ax.plot(x, m*x + b, color='gray')  # Plotting the regression line
 
     if regression_equation: 

--- a/statwrap/fpp.py
+++ b/statwrap/fpp.py
@@ -54,7 +54,7 @@ def box_model(*args, with_replacement = True, draws = 1, random_seed = None):
 
 def scatter_plot(x, y, xlim=None, ylim=None,
               ax=None, show=True, save_as=None, xlabel=None,
-              ylabel=None, title=None, regression_line=False, **kwargs):
+              ylabel=None, title=None, regression_line=False, regression_equation=False **kwargs):
     """
     Create a scatter plot of `x` versus `y`, with specified axis labels, limits, title, and other properties.
     Optionally, a regression line can be added to the plot.
@@ -115,6 +115,11 @@ def scatter_plot(x, y, xlim=None, ylim=None,
     if regression_line:
         m, b = np.polyfit(x, y, 1)  # Calculating the slope (m) and intercept (b) of the regression line
         ax.plot(x, m*x + b, color='gray')  # Plotting the regression line
+
+    if regression_equation: 
+        equation_text = f'y = {m:.2f}x + {b:.2f}'  # Add regression line equation to plot
+        ax.text(0.5 , 1, equation_text, transform=ax.transAxes, fontsize=10,
+                verticalalignment='bottom', horizontalalignment='center', alpha=0.5)
 
     if xlim is not None:
         ax.set_xlim(xlim)

--- a/statwrap/fpp.py
+++ b/statwrap/fpp.py
@@ -83,6 +83,8 @@ def scatter_plot(x, y, xlim=None, ylim=None,
         The title of the plot. Default is None.
     regression_line : bool, optional
         If True, a regression line will be added to the plot. Default is False.
+    regression_equation: bool, optional
+    	If True, the equation of the regression line will be added to the top of the plot. Default is False. 
     **kwargs : dict
         Additional keyword arguments passed to `matplotlib.pyplot.scatter`.
 
@@ -131,7 +133,8 @@ def scatter_plot(x, y, xlim=None, ylim=None,
     if ylabel is not None:
         ax.set_ylabel(ylabel)
     if title is not None:
-        ax.set_title(title, pad=12)
+        pad=12 if regression_equation else None
+	ax.set_title(title, pad=pad)
 
     if save_as is not None:
         plt.savefig(save_as)


### PR DESCRIPTION
Added functionality to scatter_plot function; additional parameter to display equation of regression line on the plot

def scatter_plot(x, y, xlim=None, ylim=None,
ax=None, show=True, save_as=None, xlabel=None,
ylabel=None, title=None, regression_line=False, regression_equation=False, **kwargs):

if regression_line=False:

![image](https://github.com/alexanderthclark/statwrap/assets/163785418/ba228fa6-3580-4c2a-9a9e-2b46cb7947ce)

if True:

![image](https://github.com/alexanderthclark/statwrap/assets/163785418/f5562230-a01c-437e-b188-0ec1ce775d94)

Additionally– the equation can still be displayed even if regression_line=False

<img width="1118" alt="Screenshot 2024-07-12 at 10 03 38 AM" src="https://github.com/user-attachments/assets/e7aa2800-ca08-4fbe-9ae9-9257f672dcc9">