### PR TITLE
get_atus_link

### DIFF
--- a/statwrap/data.py
+++ b/statwrap/data.py
@@ -88,7 +88,7 @@ def get_atus_link(file, year, multi_year=True):
     Returns
     -------
     str
-        Link to zip file.
+        Link to the zip file.
 
     Examples
     --------

--- a/statwrap/data.py
+++ b/statwrap/data.py
@@ -71,3 +71,44 @@ cezanne = {
 }
 
 paintings = pd.concat([pd.DataFrame(picasso), pd.DataFrame(cezanne)])
+
+def get_atus_link(file, year, multi_year=True):
+"""
+    Returns link to American Time Use Survey (ATUS) file data for given parameters.
+
+    Parameters
+    ----------
+    file : str
+        The name of the ATUS file ["resp", "rost", "sum", "act", "cps", "who"].
+    year : str
+        The survey year of interest.
+    multi_year : bool
+        Returns either single or multi-year data, default is True.
+
+    Returns
+    -------
+    str
+        Link to zip file.
+
+    Examples
+    --------
+    >>> get_atus_link('resp', 2023)
+    
+    (Link will return in notebook output)
+    """
+
+    base_url = "https://www.bls.gov/tus/datafiles/atus"
+    
+    # Convert the parameters to strings
+    file_str = str(file)
+    year_str = str(year)
+
+    # Multi-year handling
+    if multi_year == True:
+        year_suffix = year_str[-2:]  
+        link = f"{base_url}{file_str}-03{year_suffix}.zip"
+    else:
+        year_suffix = year_str[-2:]
+        link = f"{base_url}{file_str}-{year_suffix}.zip"
+    
+    return link

--- a/statwrap/data.py
+++ b/statwrap/data.py
@@ -73,16 +73,16 @@ cezanne = {
 paintings = pd.concat([pd.DataFrame(picasso), pd.DataFrame(cezanne)])
 
 def get_atus_link(file, year, multi_year=True):
-"""
+    """
     Returns link to American Time Use Survey (ATUS) file data for given parameters.
 
     Parameters
     ----------
     file : str
         The name of the ATUS file ["resp", "rost", "sum", "act", "cps", "who"].
-    year : str
+    year : int
         The survey year of interest.
-    multi_year : bool
+    multi_year : bool, optional
         Returns either single or multi-year data, default is True.
 
     Returns
@@ -93,22 +93,18 @@ def get_atus_link(file, year, multi_year=True):
     Examples
     --------
     >>> get_atus_link('resp', 2023)
-    
-    (Link will return in notebook output)
+    'https://www.bls.gov/tus/datafiles/atusresp-0323.zip'
     """
 
     base_url = "https://www.bls.gov/tus/datafiles/atus"
-    
-    # Convert the parameters to strings
-    file_str = str(file)
-    year_str = str(year)
+
+    # Convert the year to a string and get the last two digits
+    year_suffix = str(year)[-2:]
 
     # Multi-year handling
-    if multi_year == True:
-        year_suffix = year_str[-2:]  
-        link = f"{base_url}{file_str}-03{year_suffix}.zip"
+    if multi_year:
+        link = f"{base_url}{file}-03{year_suffix}.zip"
     else:
-        year_suffix = year_str[-2:]
-        link = f"{base_url}{file_str}-{year_suffix}.zip"
-    
+        link = f"{base_url}{file}-{year_suffix}.zip"
+
     return link


### PR DESCRIPTION
Returns link to ATUS data file; get_atus_link(file, year, multi_year=True)

Example usage: get_atus_link('resp', 2023)

<img width="522" alt="Screenshot 2024-08-08 at 11 47 56 AM" src="https://github.com/user-attachments/assets/f5d2ccb7-ac51-48e5-bdcd-3e8c12e1325b">

User can then click the link and download the file
