### PR TITLE
Improve install docs and add missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Different submodules adopt different conventions. The `fpp` submodule correspond
 
 The target user will use this package in a Google Colab or Jupyter notebook. Install with `!pip install statwrap`.
 
+If you are working from a local clone of the repository, install the required
+packages first:
+```bash
+pip install -r requirements.txt
+```
+
 Then import the package and use a magic command to load the desired module. 
 ```python
 import statwrap

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,9 @@ setuptools.setup(
         'Documentation': 'https://statwrap.readthedocs.io/'
     },
     author='Alexander Clark',
-    install_requires=['pandas','numpy','scipy', 'IPython', 'matplotlib', 'ipywidgets==7.7.1', 'odfpy', 'openpyxl'],
+    install_requires=['pandas','numpy','scipy', 'IPython', 'matplotlib',
+                      'statsmodels',
+                      'ipywidgets==7.7.1', 'odfpy', 'openpyxl'],
     author_email='',  # consider adding your email
     packages=setuptools.find_packages(),
     zip_safe=False,


### PR DESCRIPTION
## Summary
- document installing requirements when cloning the repo
- include `statsmodels` in the `setup.py` dependency list

## Testing
- `pytest -q`
