### PR TITLE
Clean imports in tests

### DIFF
--- a/tests/test_fpp.py
+++ b/tests/test_fpp.py
@@ -1,6 +1,5 @@
 import unittest
 import pandas as pd
-import matplotlib.pyplot as plt
 from statwrap.fpp import apply_pd_changes, sd, standard_units, average, r, rms_size, var, sd_plus, var_plus
 
 

--- a/tests/test_sheets.py
+++ b/tests/test_sheets.py
@@ -2,7 +2,6 @@ import unittest
 import math
 import numpy as np
 import pandas as pd
-import matplotlib.pyplot as plt
 from statwrap.sheets import linest
 
 class TestLinest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- remove unused `matplotlib.pyplot` imports from tests

## Testing
- `python -m py_compile tests/test_fpp.py tests/test_sheets.py`
- `pytest -q`