### PR TITLE
Fix var_plus division test

### DIFF
--- a/tests/test_fpp.py
+++ b/tests/test_fpp.py
@@ -232,7 +232,7 @@ class TestVariancePlus(unittest.TestCase):
 
     def test_var_plus_division_error(self):
         with self.assertRaises(ValueError):
-            sd_plus(self.single_value)
+            var_plus(self.single_value)
 
     def test_var_plus_multiple_args(self):
         result = var_plus(*self.numbers_multiple)


### PR DESCRIPTION
## Summary
- fix sample variance ValueError check to call `var_plus`

## Testing
- `pytest -q`