### PR TITLE
Expose use_all line magic in package init

### DIFF
--- a/statwrap/__init__.py
+++ b/statwrap/__init__.py
@@ -2,10 +2,11 @@ try:
     __IPYTHON__
     from .core import use_fpp
     from .core import use_sheets
+    from .core import use_all
 except NameError:
     pass
 
 __version__ = '0.2.23'
 
-__all__ = ["use_fpp", "use_sheets", "__version__"]
+__all__ = ["use_fpp", "use_sheets", "use_all", "__version__"]
 


### PR DESCRIPTION
## Summary
- export `use_all` from `statwrap.__init__` so it is available from `statwrap`

## Testing
- `pytest -q`