### PR TITLE
Add __str__ methods for custom exceptions

### DIFF
--- a/statwrap/__init__.py
+++ b/statwrap/__init__.py
@@ -6,7 +6,9 @@ try:
 except NameError:
     pass
 
+from .exceptions import StatwrapError, SimplePlotError
+
 __version__ = '0.2.23'
 
-__all__ = ["use_fpp", "use_sheets", "use_all", "__version__"]
+__all__ = ["use_fpp", "use_sheets", "use_all", "__version__", "StatwrapError", "SimplePlotError"]
 

--- a/statwrap/exceptions.py
+++ b/statwrap/exceptions.py
@@ -1,0 +1,24 @@
+class StatwrapError(Exception):
+    """Base class for all statwrap exceptions with friendly output."""
+
+    def __init__(self, message: str = ""):
+        super().__init__(message)
+        self.message = message
+
+    def __str__(self) -> str:  # pragma: no cover - simple string
+        return self.message or self.__class__.__name__
+
+    def __repr__(self) -> str:  # pragma: no cover - simple string
+        return f"{self.__class__.__name__}({self.message!r})"
+
+
+class SimplePlotError(StatwrapError):
+    """Raised when RegressionLine.plot is called with unexpected columns."""
+
+    def __str__(self) -> str:  # pragma: no cover - simple string
+        if self.message:
+            return self.message
+        return (
+            "RegressionLine.plot() requires simple linear regression with a single"
+            " predictor column"
+        )

--- a/statwrap/utils.py
+++ b/statwrap/utils.py
@@ -6,6 +6,7 @@ import functools
 import re
 import pandas as pd
 import statwrap.fpp as fpp
+from .exceptions import SimplePlotError
 import matplotlib.pyplot as plt
 from statsmodels.graphics.regressionplots import (
     plot_partregress_grid,
@@ -378,7 +379,9 @@ class RegressionLine(Hyperplane):
         """Make a plot with regression line. Only works for simple linear regression."""
 
         if len(self.x.columns) != 2:
-            raise Exception("Unexpected number of columns. simple_plot only works for simple linear regression.")
+            raise SimplePlotError(
+                "plot() only works for simple linear regression with one predictor column"
+            )
         x = self.x.iloc[:,1]
 
         if ax is None:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,25 @@
+import unittest
+import pandas as pd
+
+# Ensure modules import in order to avoid circular import
+import statwrap.fpp
+from statwrap.sheets import linest
+from statwrap.exceptions import StatwrapError, SimplePlotError
+
+
+class TestPlotExceptions(unittest.TestCase):
+    def test_plot_multivariate_raises(self):
+        y = [1, 2, 3]
+        X = pd.DataFrame({"a": [1, 2, 3], "b": [2, 3, 4], "c": [3, 4, 5]})
+        model = linest(y, X)
+        with self.assertRaises(SimplePlotError):
+            model.plot(show=False)
+
+    def test_exception_str(self):
+        err = SimplePlotError("bad stuff")
+        self.assertEqual(str(err), "bad stuff")
+        self.assertIn("SimplePlotError", repr(err))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `__str__`/`__repr__` for `StatwrapError` and `SimplePlotError`
- test that the new string representations work

## Testing
- `pytest -q`