### PR TITLE
Fix random_seed parameter usage in box_model

### DIFF
--- a/statwrap/fpp.py
+++ b/statwrap/fpp.py
@@ -51,7 +51,7 @@ def box_model(*args, with_replacement = True, draws = 1, random_seed = None):
 
     if not isinstance(draws, (int, np.integer)) or draws < 1:
         raise ValueError("draws must be a positive integer")
-    if random_seed:
+    if random_seed is not None:
         rng = np.random.default_rng(random_seed)
         X = rng.choice(a, replace=with_replacement, size=draws)
     else:

--- a/tests/test_fpp.py
+++ b/tests/test_fpp.py
@@ -273,6 +273,11 @@ class TestBoxModel(unittest.TestCase):
         with self.assertRaises(ValueError):
             box_model(1, 2, 3, draws=1.5)
 
+    def test_random_seed_reproducibility(self):
+        result1 = box_model([1, 2], draws=2, random_seed=0)
+        result2 = box_model([1, 2], draws=2, random_seed=0)
+        self.assertEqual(result1, result2)
+
 
 class TestArgsToArray(unittest.TestCase):
 


### PR DESCRIPTION
## Summary
- handle `random_seed=0` in `box_model`
- test reproducibility when passing `random_seed`

## Testing
- `pytest -q`