### PR TITLE
Fix box_model docstring output and return type tests

### DIFF
--- a/statwrap/fpp.py
+++ b/statwrap/fpp.py
@@ -42,16 +42,16 @@ def box_model(*args, with_replacement = True, draws = 1, random_seed = None):
     Examples
     --------
     >>> box_model([1,2,3,4,5,6], with_replacement=True, draws=3)
-    array([2, 5, 5])
+    [2, 5, 5]
 
     >>> box_model((1,2,3,4,5,6), with_replacement=False, draws=3)
-    array([4, 2, 6])
+    [4, 2, 6]
     """
     a = args_to_array(args)
 
     if not isinstance(draws, (int, np.integer)) or draws < 1:
         raise ValueError("draws must be a positive integer")
-    if random_seed:
+    if random_seed is not None:
         rng = np.random.default_rng(random_seed)
         X = rng.choice(a, replace=with_replacement, size=draws)
     else:

--- a/tests/test_fpp.py
+++ b/tests/test_fpp.py
@@ -1,5 +1,6 @@
 import unittest
 import pandas as pd
+import numpy as np
 from statwrap.fpp import (
     apply_pd_changes,
     sd,
@@ -272,6 +273,20 @@ class TestBoxModel(unittest.TestCase):
     def test_invalid_draws_float(self):
         with self.assertRaises(ValueError):
             box_model(1, 2, 3, draws=1.5)
+
+    def test_single_draw_returns_scalar(self):
+        result = box_model(1, 2, 3, draws=1)
+        self.assertIsInstance(result, (int, float, np.integer, np.floating))
+
+    def test_multiple_draws_returns_list(self):
+        result = box_model(1, 2, 3, draws=3)
+        self.assertIsInstance(result, list)
+
+    def test_random_seed_reproducibility(self):
+        result1 = box_model([1, 2], draws=2, random_seed=0)
+        result2 = box_model([1, 2], draws=2, random_seed=0)
+        self.assertEqual(result1, result2)
+
 
 
 class TestArgsToArray(unittest.TestCase):


### PR DESCRIPTION
## Summary
- update `box_model` examples in `statwrap/fpp.py` to display lists
- verify `box_model` return types and reproducibility in `tests/test_fpp.py`
- merged latest `main` changes

## Testing
- `pytest -q`